### PR TITLE
Change TargetFramework to .netstandard 2.0

### DIFF
--- a/src/Infolyzer.IcuParser.UnitTests/Infolyzer.IcuParser.UnitTests.csproj
+++ b/src/Infolyzer.IcuParser.UnitTests/Infolyzer.IcuParser.UnitTests.csproj
@@ -1,12 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Infolyzer.IcuParser/Infolyzer.IcuParser.csproj
+++ b/src/Infolyzer.IcuParser/Infolyzer.IcuParser.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <IsPackable>true</IsPackable>
     <Description>ICU message format parser.</Description>
     <Copyright>Infolyzer AB 2019</Copyright>
     <Company>Infolyzer AB</Company>

--- a/src/Infolyzer.IcuParser/Infolyzer.IcuParser.nuspec
+++ b/src/Infolyzer.IcuParser/Infolyzer.IcuParser.nuspec
@@ -13,7 +13,7 @@
     <projectUrl>https://github.com/fredrikholm/Infolyzer.IcuParser</projectUrl>
     <tags>#icu #parser #messageformat</tags>
     <dependencies>
-      <group targetFramework=".NETCoreApp2.2" />
+      <group targetFramework="netstandard2.0" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
This addresses #2 

## Description
- change the target framework to .net standard 2.0 so it supports .net 2.0+, .net Framework 4.6.1+ and more [see here](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0)
- change the tests to use .net 8.0 and .net framework 4.8 to perform the tests (I think one representative for .net "core" and .net framework, each, should be enough)
- updated test project dependencies

## Tests Performed
The unit tests still pass, I haven't done any in-product testing.